### PR TITLE
Double booking problem

### DIFF
--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -6,10 +6,15 @@ class BookingsController < ApplicationController
     @booking.user = current_user
     authorize @booking
     set_booking_period
-    if @booking.save
-      redirect_to dashboard_path
-    else
-      redirect_to capsule_path(@capsule)
+    @capsule.bookings.each do |existing_booking|
+      # check if start_date or end_date of new booking is inside range of existing booking
+      if (@booking.period_start >= existing_booking.period_start && @booking.period_start <= existing_booking.period_end) || (@booking.period_end >= existing_booking.period_start && @booking.period_end <= existing_booking.period_end)
+        redirect_to capsule_path(@capsule), status: :unprocessable_entity
+      elsif @booking.save
+        redirect_to dashboard_path
+      else
+        redirect_to capsule_path(@capsule)
+      end
     end
   end
 

--- a/app/controllers/bookings_controller.rb
+++ b/app/controllers/bookings_controller.rb
@@ -6,15 +6,20 @@ class BookingsController < ApplicationController
     @booking.user = current_user
     authorize @booking
     set_booking_period
+    booked_already = false
     @capsule.bookings.each do |existing_booking|
-      # check if start_date or end_date of new booking is inside range of existing booking
-      if (@booking.period_start >= existing_booking.period_start && @booking.period_start <= existing_booking.period_end) || (@booking.period_end >= existing_booking.period_start && @booking.period_end <= existing_booking.period_end)
-        redirect_to capsule_path(@capsule), status: :unprocessable_entity
-      elsif @booking.save
-        redirect_to dashboard_path
-      else
-        redirect_to capsule_path(@capsule)
+      if ((@booking.period_start >= existing_booking.period_start && @booking.period_start <= existing_booking.period_end) || (@booking.period_end >= existing_booking.period_start && @booking.period_end <= existing_booking.period_end)) && existing_booking.accepted?
+        booked_already = true
       end
+    end
+    if booked_already == true
+      flash[:alert] = "Sorry, already booked!"
+      redirect_to capsule_path(@capsule), status: :unprocessable_entity
+    elsif @booking.save
+      redirect_to dashboard_path
+    else
+      flash[:alert] = "Sorry, booking could not be processed!"
+      redirect_to capsule_path(@capsule)
     end
   end
 

--- a/app/views/dashboards/dashboard.html.erb
+++ b/app/views/dashboards/dashboard.html.erb
@@ -18,8 +18,8 @@
         <li>
           Booking ID: <%= booking.id %>
           <% if booking.pending? %>
-            <%= link_to "Accept", accept_capsule_booking_path(capsule, booking),  data: { confirm: 'Are you sure?' }%>
-            <%= link_to "Decline", decline_capsule_booking_path(capsule, booking),  data: { confirm: 'Are you sure?' }%>
+            <%= link_to "Accept", accept_capsule_booking_path(capsule, booking),  data: { turbo_method: :patch, turbo_confirm: "Are you sure you want to accept?" }%>
+            <%= link_to "Decline", decline_capsule_booking_path(capsule, booking),  data: { turbo_method: :patch, turbo_confirm: "Are you sure you want to decline?" }%>
           <% else %>
             <%= booking.status %>
           <% end %>

--- a/app/views/dashboards/dashboard.html.erb
+++ b/app/views/dashboards/dashboard.html.erb
@@ -16,7 +16,7 @@
     <div>
       <% capsule.bookings.each do |booking| %>
         <li>
-          Booking ID: <%= booking.id %>
+          Booking ID: <%= booking.id %><%= booking.period_start %><%= booking.period_end %>
           <% if booking.pending? %>
             <%= link_to "Accept", accept_capsule_booking_path(capsule, booking),  data: { turbo_method: :patch, turbo_confirm: "Are you sure you want to accept?" }%>
             <%= link_to "Decline", decline_capsule_booking_path(capsule, booking),  data: { turbo_method: :patch, turbo_confirm: "Are you sure you want to decline?" }%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,8 @@ Rails.application.routes.draw do
 
   resources :capsules, only: %i[index show new create] do
     resources :bookings, only: %i[create update] do
-      get :accept, on: :member
-      get :decline, on: :member
+      patch :accept, on: :member
+      patch :decline, on: :member
     end
   end
 


### PR DESCRIPTION
When adding a booking, it is checked, if there is a booking that has an overlap with the date inserted by the user AND is accepted by the host already.
This gives the host the ability to receive multiple booking requests for the same days and freely decide which one to accept.